### PR TITLE
feat: ignore node modules and binaries

### DIFF
--- a/js/local.js
+++ b/js/local.js
@@ -1,6 +1,8 @@
 import { displayDirectoryStructure, sortContents, getSelectedFiles, formatRepoContents } from './utils.js';
 import { extractZipContents } from './zip-utils.js';
 
+const defaultIgnore = ['.git/**', 'node_modules/**', '**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.gif', '**/*.svg', '**/*.ico', '**/*.webp', '**/*.bmp', '**/*.pdf', '**/*.zip', '**/*.tar', '**/*.gz', '**/*.rar', '**/*.7z', '**/*.mp3', '**/*.mp4', '**/*.mov', '**/*.avi', '**/*.mkv', '**/*.exe', '**/*.dll', '**/*.bin'];
+
 // Add at the top of the file with other imports
 let pathZipMap = {};
 
@@ -14,7 +16,7 @@ async function handleDirectorySelection(event) {
     const files = event.target.files;
     if (files.length === 0) return;
 
-    const gitignoreContent = ['.git/**']
+    const gitignoreContent = [...defaultIgnore]
     const tree = [];
     for (let file of files) {
         const filePath = file.webkitRelativePath.startsWith('/') ? file.webkitRelativePath.slice(1) : file.webkitRelativePath;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,6 +1,14 @@
 // Display directory structure
 function displayDirectoryStructure(tree) {
-    tree = tree.filter(item => item.type === 'blob').sort(sortContents);
+    const binaryExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico', '.webp', '.bmp', '.pdf', '.zip', '.tar', '.gz', '.rar', '.7z', '.mp3', '.mp4', '.mov', '.avi', '.mkv', '.exe', '.dll', '.bin'];
+    tree = tree
+        .filter(item => {
+            if (item.type !== 'blob') return false;
+            const lowerPath = item.path.toLowerCase();
+            if (lowerPath.split('/').includes('node_modules')) return false;
+            return !binaryExtensions.some(ext => lowerPath.endsWith(ext));
+        })
+        .sort(sortContents);
     const container = document.getElementById('directoryStructure');
     container.innerHTML = '';
     const rootUl = document.createElement('ul');

--- a/js/zip-utils.js
+++ b/js/zip-utils.js
@@ -3,7 +3,7 @@ async function extractZipContents(zipFile) {
     try {
         const zip = await JSZip.loadAsync(zipFile);
         const tree = [];
-        const gitignoreContent = ['.git/**'];
+        const gitignoreContent = ['.git/**', 'node_modules/**', '**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.gif', '**/*.svg', '**/*.ico', '**/*.webp', '**/*.bmp', '**/*.pdf', '**/*.zip', '**/*.tar', '**/*.gz', '**/*.rar', '**/*.7z', '**/*.mp3', '**/*.mp4', '**/*.mov', '**/*.avi', '**/*.mkv', '**/*.exe', '**/*.dll', '**/*.bin'];
         let pathZipMap = {};
 
         // Process each file in the zip


### PR DESCRIPTION
## Summary
- skip node_modules and common binary files when selecting local repos or zips
- hide node_modules and binaries when displaying repo contents

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9dd5e288832b880fa2fc9d58f86b